### PR TITLE
Split HANA deployment and HANA DB license installation in 2 different scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is also important that your disks are setup according to the [SAP storage req
 |lss_backup_password|Local Secure Store Auto Backup Password|yes|
 |hana_install_path|Installation Path for SAP HANA|no, defaulted to `/hana/shared` value|
 |hana_sid|SAP HANA System ID|yes|
-|hana_instance_number|Instance Number|yes|
+|hana_instance_number|Instance Number|yes - **note the required double quotes while adding the variable to your inventory so this is interpreted as a string** |
 |hana_env_type|System Usage, Valid values: production, test, development or custom|no, defaulted to `production` value|
 |hana_mem_restrict|Restrict maximum memory allocation|no, defaulted to `y` value|
 |hana_max_mem|Maximum Memory Allocation in MB|yes (unless `hana_mem_restrict` value is `n`)|
@@ -111,7 +111,7 @@ sapcar_file_name: SAPCAR_1311-80000935.EXE
 root_password: "mysecretpassword"
 sapadm_password: "mysecretpassword"
 hana_sid: RHE
-hana_instance_number: 01
+hana_instance_number: "01"
 hana_env_type: development
 hana_mem_restrict: 'n'
 hana_master_password: "mysecretpassword"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ It is also important that your disks are setup according to the [SAP storage req
 |license_path|Target host directory path where HANA license file located|no, required if `apply_license` true|
 |license_file_name|HANA license file name|no, required if `apply_license` true|
 
-## HANA Deploy and HANA Lincese 
+## HANA Deploy and HANA Lincese
 
 While using this role 2 different scenarios cna be covered. These are SAP HANA deployment in a new RHEL Server and set the HANA DB License in an existing deployment.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sap-hana-deployment [![Build Status](https://travis-ci.com/redhat-sap/sap-hana-deployment.svg?branch=master)](https://travis-ci.com/redhat-sap/sap-hana-deployment)
 
-This role installs SAP HANA on a RHEL 7.x or 8.x system.
+This role installs SAP HANA on a RHEL 7.x or 8.x system and applies a permament HANA License.
 
 ## Requirements
 
@@ -74,6 +74,16 @@ It is also important that your disks are setup according to the [SAP storage req
 |apply_license|Whether to apply a License File to the deployed HANA instance|no, defaulted to 'false'|
 |license_path|Target host directory path where HANA license file located|no, required if `apply_license` true|
 |license_file_name|HANA license file name|no, required if `apply_license` true|
+
+## HANA Deploy and HANA Lincese 
+
+While using this role 2 different scenarios cna be covered. These are SAP HANA deployment in a new RHEL Server and set the HANA DB License in an existing deployment.
+
+In order the role to run the first scenario, SAP HANA deployment in a new RHEL Server, the variable `apply_license` must be `false`.
+
+In order the role to run the second scenario, set the HANA DB License in an existing deployment, the variable `apply_license` must be `true`.
+
+Variables required for both scenarios are the ones specified already.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It is also important that your disks are setup according to the [SAP storage req
 
 ## HANA Deploy and HANA Lincese
 
-While using this role 2 different scenarios cna be covered. These are SAP HANA deployment in a new RHEL Server and set the HANA DB License in an existing deployment.
+While using this role 2 different scenarios can be covered. These are SAP HANA deployment in a new RHEL Server and set the HANA DB License in an existing deployment.
 
 In order the role to run the first scenario, SAP HANA deployment in a new RHEL Server, the variable `apply_license` must be `false`.
 

--- a/tasks/license.yml
+++ b/tasks/license.yml
@@ -2,7 +2,7 @@
 
 - name: Apply HANA license to the new deployed instance
   shell: |
-      /usr/sap/{{ hana_sid}} | upper/HDB{{ hana_instance_number }}/exe/hdbsql -i {{ hana_instance_number }} -u SYSTEM -p {{ hana_db_system_password }} -m <<EOF
+      /usr/sap/{{ hana_sid | upper }}/HDB{{ hana_instance_number }}/exe/hdbsql -i {{ hana_instance_number }} -u SYSTEM -p {{ hana_db_system_password }} -m <<EOF
       SET SYSTEM LICENSE '$(cat {{ license_path }}/{{ license_file_name }})';
       EOF
   args:

--- a/tasks/license.yml
+++ b/tasks/license.yml
@@ -2,7 +2,7 @@
 
 - name: Apply HANA license to the new deployed instance
   shell: |
-      /usr/sap/RHE/HDB01/exe/hdbsql -i {{ hana_instance_number }} -u SYSTEM -p {{ hana_db_system_password }} -m <<EOF
+      /usr/sap/{{ hana_sid}} | upper/HDB{{ hana_instance_number }}/exe/hdbsql -i {{ hana_instance_number }} -u SYSTEM -p {{ hana_db_system_password }} -m <<EOF
       SET SYSTEM LICENSE '$(cat {{ license_path }}/{{ license_file_name }})';
       EOF
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,20 @@
 ---
 
 - import_tasks: ev_user.yml
-  when: hana_userid == ''
+  when: 
+    - hana_userid == ''
+    - not apply_license
 
 - import_tasks: ev_group.yml
-  when: hana_groupid == ''
+  when: 
+    - hana_groupid == ''
+    - not apply_license
 
 - import_tasks: password_facts.yml
   when: use_master_password == 'y'
 
 - import_tasks: hana_deploy.yml
+  when: not apply_license
 
 - import_tasks: license.yml
   when: apply_license

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
 - import_tasks: ev_user.yml
-  when: 
+  when:
     - hana_userid == ''
     - not apply_license
 
 - import_tasks: ev_group.yml
-  when: 
+  when:
     - hana_groupid == ''
     - not apply_license
 


### PR DESCRIPTION
As HANA DB License can not be downloaded before the HANA instance has been deployed, this role needs to be split into 2 different phases where we can choose from HANA deployment and License installation