### PR TITLE
Normalize vars name to match role name and fix not mandatory vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - '3.7'
   - '3.6'
   - '3.5'
-  - '2.7'
 
 install:
   - pip install ansible-lint

--- a/README.md
+++ b/README.md
@@ -34,54 +34,54 @@ It is also important that your disks are setup according to the [SAP storage req
 
 | variable | info | required? |
 |:--------:|:----:|:---------:|
-|bundle_path|Target host directory path where SAP Installation Bundle SAR file is located|yes|
-|bundle_sar_file_name|Installation Bundle SAR file name|yes|
-|sapcar_path|Target host directory directory path where SAPCAR tool file is located|yes|
-|sapcar_file_name|SAPCAR tool file name|yes|
-|deploy_hostagent|Whatever you want to deploy SAP HostAgent or not|no, defaulted to `n` value|
-|use_master_password|Use single master password for all users, created during installation|no, defaulted to `n` value|
-|common_master_password|Common password for both OS users and DB Administrator user (SYSTEM)|no, only if use_master_password is `y`|
-|root_password|Root User Password|yes|
-|sapadm_password|SAP Host Agent User (sapadm) Password|no, will take the value from `common_master_password` when `use_master_password` is `y`|
-|sidadm_password|Password for user \<sid>adm|no, will take the value from `common_master_password` when `use_master_password` is `y`|
-|hana_db_system_password|Database User (SYSTEM) Password|no, will take the value from `common_master_password` when `use_master_password` is `y`|
-|ase_user_password|SAP ASE Administrator Password|yes|
-|xs_org_password|XS Advanced Admin User Password|Only if `xs_install` is `y`|
-|lss_user_password|Local Secure Store User Password|yes|
-|lss_backup_password|Local Secure Store Auto Backup Password|yes|
-|hana_install_path|Installation Path for SAP HANA|no, defaulted to `/hana/shared` value|
-|hana_sid|SAP HANA System ID|yes|
-|hana_instance_number|Instance Number|yes - **note the required double quotes while adding the variable to your inventory so this is interpreted as a string** |
-|hana_env_type|System Usage, Valid values: production, test, development or custom|no, defaulted to `production` value|
-|hana_mem_restrict|Restrict maximum memory allocation|no, defaulted to `y` value|
-|hana_max_mem|Maximum Memory Allocation in MB|yes (unless `hana_mem_restrict` value is `n`)|
-|hana_userid|System Administrator User ID|no, defaulted to next available user ID|
-|hana_groupid|ID of User Group|no, defaulted next available group ID|
-|system_restart|Restart system after machine reboot|no, defaulted to `n`|
-|xs_install|Install XS Advanced in the default tenant database|no, defaulted to `n`|
-|xs_path|XS Advanced App Working Path|Only if `xs_install` is `y`|
-|xs_orgname|Organization Name For Space "SAP"|Only if `xs_install` is `y`, defaulted to `orgname`|
-|xs_org_user|XS Advanced Admin User|Only if `xs_install` is `y`, defaulted to `XSA_ADMIN`|
-|xs_prod_space|Customer Space Name|Only if `xs_install` is `y`, defaulted to `PROD`|
-|xs_routing_mode|Routing Mode (Valid values: ports and hostnames)|Only if `xs_install` is `y`, defaulted to `ports`|
-|xs_domain_name|XS Advanced Domain Name|Only if `xs_install` is `y`|
-|xs_sap_space_user|XS Advanced SAP Space OS User ID|Only if `xs_install` is `y`|
-|xs_customer_space_user|XS Advanced Customer Space OS User ID|Only if `xs_install` is `y`|
-|xs_components|XS Advanced Components|Only if `xs_install` is `y`|
-|xs_components_nostart|Do not start the selected XS Advanced components after installation|Only if `xs_install` is `y`, defaulted to `none`|
-|lss_user|Local Secure Store User ID|yes|
-|lss_group|Local Secure Store User Group ID|yes|
-|apply_license|Whether to apply a License File to the deployed HANA instance|no, defaulted to 'false'|
-|license_path|Target host directory path where HANA license file located|no, required if `apply_license` true|
-|license_file_name|HANA license file name|no, required if `apply_license` true|
+|sap_hana_deployment_bundle_path|Target host directory path where SAP Installation Bundle SAR file is located|yes|
+|sap_hana_deployment_bundle_sar_file_name|Installation Bundle SAR file name|yes|
+|sap_hana_deployment_sapcar_path|Target host directory directory path where SAPCAR tool file is located|yes|
+|sap_hana_deployment_sapcar_file_name|SAPCAR tool file name|yes|
+|sap_hana_deployment_deploy_hostagent|Whatever you want to deploy SAP HostAgent or not|no, defaulted to `n` value|
+|sap_hana_deployment_use_master_password|Use single master password for all users, created during installation|no, defaulted to `n` value|
+|sap_hana_deployment_common_master_password|Common password for both OS users and DB Administrator user (SYSTEM)|no, only if sap_hana_deployment_use_master_password is `y`|
+|sap_hana_deployment_root_password|Root User Password|yes|
+|sap_hana_deployment_sapadm_password|SAP Host Agent User (sapadm) Password|no, will take the value from `sap_hana_deployment_common_master_password` when `sap_hana_deployment_use_master_password` is `y`|
+|sap_hana_deployment_sidadm_password|Password for user \<sid>adm|no, will take the value from `sap_hana_deployment_common_master_password` when `sap_hana_deployment_use_master_password` is `y`|
+|sap_hana_deployment_hana_db_system_password|Database User (SYSTEM) Password|no, will take the value from `sap_hana_deployment_common_master_password` when `sap_hana_deployment_use_master_password` is `y`|
+|sap_hana_deployment_ase_user_password|SAP ASE Administrator Password|yes|
+|sap_hana_deployment_xs_org_password|XS Advanced Admin User Password|Only if `sap_hana_deployment_xs_install` is `y`|
+|sap_hana_deployment_lss_user_password|Local Secure Store User Password|no|
+|sap_hana_deployment_lss_backup_password|Local Secure Store Auto Backup Password|no|
+|sap_hana_deployment_hana_install_path|Installation Path for SAP HANA|no, defaulted to `/hana/shared` value|
+|sap_hana_deployment_hana_sid|SAP HANA System ID|yes|
+|sap_hana_deployment_hana_instance_number|Instance Number|yes - **note the required double quotes while adding the variable to your inventory so this is interpreted as a string** |
+|sap_hana_deployment_hana_env_type|System Usage, Valid values: production, test, development or custom|no, defaulted to `production` value|
+|sap_hana_deployment_hana_mem_restrict|Restrict maximum memory allocation|no, defaulted to `y` value|
+|sap_hana_deployment_hana_max_mem|Maximum Memory Allocation in MB|yes (unless `sap_hana_deployment_hana_mem_restrict` value is `n`)|
+|sap_hana_deployment_hana_userid|System Administrator User ID|no, defaulted to next available user ID|
+|sap_hana_deployment_hana_groupid|ID of User Group|no, defaulted next available group ID|
+|sap_hana_deployment_system_restart|Restart system after machine reboot|no, defaulted to `n`|
+|sap_hana_deployment_xs_install|Install XS Advanced in the default tenant database|no, defaulted to `n`|
+|sap_hana_deployment_xs_path|XS Advanced App Working Path|Only if `sap_hana_deployment_xs_install` is `y`|
+|sap_hana_deployment_xs_orgname|Organization Name For Space "SAP"|Only if `sap_hana_deployment_xs_install` is `y`, defaulted to `orgname`|
+|sap_hana_deployment_xs_org_user|XS Advanced Admin User|Only if `sap_hana_deployment_xs_install` is `y`, defaulted to `XSA_ADMIN`|
+|sap_hana_deployment_xs_prod_space|Customer Space Name|Only if `sap_hana_deployment_xs_install` is `y`, defaulted to `PROD`|
+|sap_hana_deployment_xs_routing_mode|Routing Mode (Valid values: ports and hostnames)|Only if `sap_hana_deployment_xs_install` is `y`, defaulted to `ports`|
+|sap_hana_deployment_xs_domain_name|XS Advanced Domain Name|Only if `sap_hana_deployment_xs_install` is `y`|
+|sap_hana_deployment_xs_sap_space_user|XS Advanced SAP Space OS User ID|Only if `sap_hana_deployment_xs_install` is `y`|
+|sap_hana_deployment_xs_customer_space_user|XS Advanced Customer Space OS User ID|Only if `sap_hana_deployment_xs_install` is `y`|
+|sap_hana_deployment_xs_components|XS Advanced Components|Only if `sap_hana_deployment_xs_install` is `y`|
+|sap_hana_deployment_xs_components_nostart|Do not start the selected XS Advanced components after installation|Only if `sap_hana_deployment_xs_install` is `y`, defaulted to `none`|
+|sap_hana_deployment_lss_user|Local Secure Store User ID|no|
+|sap_hana_deployment_lss_group|Local Secure Store User Group ID|no|
+|sap_hana_deployment_apply_license|Whether to apply a License File to the deployed HANA instance|no, defaulted to 'false'|
+|sap_hana_deployment_license_path|Target host directory path where HANA license file located|no, required if `sap_hana_deployment_apply_license` true|
+|sap_hana_deployment_license_file_name|HANA license file name|no, required if `sap_hana_deployment_apply_license` true|
 
 ## HANA Deploy and HANA Lincese
 
 While using this role 2 different scenarios can be covered. These are SAP HANA deployment in a new RHEL Server and set the HANA DB License in an existing deployment.
 
-In order the role to run the first scenario, SAP HANA deployment in a new RHEL Server, the variable `apply_license` must be `false`.
+In order the role to run the first scenario, SAP HANA deployment in a new RHEL Server, the variable `sap_hana_deployment_apply_license` must be `false`.
 
-In order the role to run the second scenario, set the HANA DB License in an existing deployment, the variable `apply_license` must be `true`.
+In order the role to run the second scenario, set the HANA DB License in an existing deployment, the variable `sap_hana_deployment_apply_license` must be `true`.
 
 Variables required for both scenarios are the ones specified already.
 
@@ -104,26 +104,21 @@ The upstream version of these role can be found [here](https://github.com/linux-
 ## Example Inventory
 
 ```yaml
-bundle_path: /usr/local/src
-bundle_sar_file_name: IMDB_SERVER20_045_0-80002031.SAR
-sapcar_path: /usr/local/src
-sapcar_file_name: SAPCAR_1311-80000935.EXE
-root_password: "mysecretpassword"
-sapadm_password: "mysecretpassword"
-hana_sid: RHE
-hana_instance_number: "01"
-hana_env_type: development
-hana_mem_restrict: 'n'
-hana_master_password: "mysecretpassword"
-hana_db_system_password: "mysecretpassword"
-lss_user: lsadm
-lss_group: lsgrp
-lss_user_password: "mysecretpassword"
-lss_backup_password: "mysecretpassword"
-ase_user_password: "mysecretpassword"
-apply_license: true
-license_path: /usr/local/src
-license_file_name: RHE.txt
+sap_hana_deployment_bundle_path: /usr/local/src
+sap_hana_deployment_bundle_sar_file_name: IMDB_SERVER20_045_0-80002031.SAR
+sap_hana_deployment_sapcar_path: /usr/local/src
+sap_hana_deployment_sapcar_file_name: SAPCAR_1311-80000935.EXE
+sap_hana_deployment_root_password: "mysecretpassword"
+sap_hana_deployment_sapadm_password: "mysecretpassword"
+sap_hana_deployment_hana_sid: RHE
+sap_hana_deployment_hana_instance_number: "01"
+sap_hana_deployment_hana_env_type: development
+sap_hana_deployment_hana_mem_restrict: 'n'
+sap_hana_deployment_hana_db_system_password: "mysecretpassword"
+sap_hana_deployment_ase_user_password: "mysecretpassword"
+sap_hana_deployment_apply_license: true
+sap_hana_deployment_license_path: /usr/local/src
+sap_hana_deployment_license_file_name: RHE.txt
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,51 +2,51 @@
 # Adapt to your default settings
 
 # Target host path and file name for the bundle installation file
-bundle_path:
-bundle_sar_file_name:
+sap_hana_deployment_bundle_path:
+sap_hana_deployment_bundle_sar_file_name:
 
 # Target host path and file name for the sapcar installation file
-sapcar_path:
-sapcar_file_name:
+sap_hana_deployment_sapcar_path:
+sap_hana_deployment_sapcar_file_name:
 
 # Target host path and file name for the license file
-license_path:
-license_file_name:
+sap_hana_deployment_license_path:
+sap_hana_deployment_license_file_name:
 
 
 # Response variables for unattended installation config file
 
-deploy_hostagent: 'n'
-apply_license: false
-hana_install_path: '/hana/shared'
-use_master_password: 'n'
-root_password:
-sapadm_password:
-hana_sid:
-hana_instance_number:
-hana_env_type: 'production'
-hana_mem_restrict: 'y'
-hana_max_mem:
-common_master_password:
-sidadm_password:
-hana_userid:
-hana_groupid:
-hana_db_system_password:
-system_restart: 'n'
-xs_install: 'n'
-xs_path:
-xs_orgname: 'orgname'
-xs_org_user: 'XSA_ADMIN'
-xs_org_password:
-xs_prod_space: 'PROD'
-xs_routing_mode: 'ports'
-xs_domain_name:
-xs_sap_space_user:
-xs_customer_space_user:
-xs_components:
-xs_components_nostart: 'none'
-lss_user:
-lss_group:
-lss_user_password:
-lss_backup_password:
-ase_user_password:
+sap_hana_deployment_deploy_hostagent: 'n'
+sap_hana_deployment_apply_license: false
+sap_hana_deployment_hana_install_path: '/hana/shared'
+sap_hana_deployment_use_master_password: 'n'
+sap_hana_deployment_root_password:
+sap_hana_deployment_sapadm_password:
+sap_hana_deployment_hana_sid:
+sap_hana_deployment_hana_instance_number:
+sap_hana_deployment_hana_env_type: 'production'
+sap_hana_deployment_hana_mem_restrict: 'y'
+sap_hana_deployment_hana_max_mem:
+sap_hana_deployment_common_master_password:
+sap_hana_deployment_sidadm_password:
+sap_hana_deployment_hana_userid:
+sap_hana_deployment_hana_groupid:
+sap_hana_deployment_hana_db_system_password:
+sap_hana_deployment_system_restart: 'n'
+sap_hana_deployment_xs_install: 'n'
+sap_hana_deployment_xs_path:
+sap_hana_deployment_xs_orgname: 'orgname'
+sap_hana_deployment_xs_org_user: 'XSA_ADMIN'
+sap_hana_deployment_xs_org_password:
+sap_hana_deployment_xs_prod_space: 'PROD'
+sap_hana_deployment_xs_routing_mode: 'ports'
+sap_hana_deployment_xs_domain_name:
+sap_hana_deployment_xs_sap_space_user:
+sap_hana_deployment_xs_customer_space_user:
+sap_hana_deployment_xs_components:
+sap_hana_deployment_xs_components_nostart: 'none'
+sap_hana_deployment_lss_user:
+sap_hana_deployment_lss_group:
+sap_hana_deployment_lss_user_password:
+sap_hana_deployment_lss_backup_password:
+sap_hana_deployment_ase_user_password:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,6 @@
 galaxy_info:
   author: Red Hat SAP Community of Practice
   description: Deploys `SAP HANA` on the given host(s)
-  version: 0.1
   license: GPLv3
   min_ansible_version: 2.5
   platforms:

--- a/tasks/ev_group.yml
+++ b/tasks/ev_group.yml
@@ -15,10 +15,10 @@
 
 - name: Set fact for Group ID when 'sapsys' group does not exist
   set_fact:
-    hana_groupid: "{{ nextgroupid.stdout }}"
+    sap_hana_deployment_hana_groupid: "{{ nextgroupid.stdout }}"
   when: checkgroup.stdout | length = 0
 
 - name: Set fact for Group ID when 'sapsys' group does exist
   set_fact:
-    hana_groupid: "{{ checkgroup.stdout }}"
+    sap_hana_deployment_hana_groupid: "{{ checkgroup.stdout }}"
   when: checkgroup.stdout | length > 0

--- a/tasks/ev_user.yml
+++ b/tasks/ev_user.yml
@@ -9,4 +9,4 @@
 
 - name: Set fact for User ID
   set_fact:
-    hana_userid: "{{ nextuserid.stdout }}"
+    sap_hana_deployment_hana_userid: "{{ nextuserid.stdout }}"

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -1,15 +1,18 @@
 ---
 
 - name: Use SAPCAR to extract the SAP HANA Bundle SAR file
-  command: "{{ sapcar_path }}/{{ sapcar_file_name }} -xvf {{ bundle_path }}/{{ bundle_sar_file_name }} -manifest SIGNATURE.SMF"
+  command: >-
+    {{ sap_hana_deployment_sapcar_path }}/{{ sap_hana_deployment_sapcar_file_name }} \
+    -xvf {{ sap_hana_deployment_bundle_path }}/{{ sap_hana_deployment_bundle_sar_file_name }} \
+    -manifest SIGNATURE.SMF
   register: extractbundle
   args:
-    chdir: "{{ sapcar_path }}"
+    chdir: "{{ sap_hana_deployment_sapcar_path }}"
   changed_when: "'SAPCAR: processing archive' in extractbundle.stdout"
 
 - name: Setting fact for HANA installer path
   set_fact:
-    hana_source_path: "{{ sapcar_path }}/SAP_HANA_DATABASE"
+    hana_source_path: "{{ sap_hana_deployment_sapcar_path }}/SAP_HANA_DATABASE"
 
 - name: create temporary directory to store the processed template
   tempfile:

--- a/tasks/license.yml
+++ b/tasks/license.yml
@@ -2,12 +2,13 @@
 
 - name: Apply HANA license to the new deployed instance
   shell: |
-      /usr/sap/{{ hana_sid | upper }}/HDB{{ hana_instance_number }}/exe/hdbsql -i {{ hana_instance_number }} -u SYSTEM -p {{ hana_db_system_password }} -m <<EOF
-      SET SYSTEM LICENSE '$(cat {{ license_path }}/{{ license_file_name }})';
+      /usr/sap/{{ sap_hana_deployment_hana_sid | upper }}/HDB{{ sap_hana_deployment_hana_instance_number }}/exe/hdbsql \
+      -i {{ sap_hana_deployment_hana_instance_number }} -u SYSTEM -p {{ sap_hana_deployment_hana_db_system_password }} -m <<EOF
+      SET SYSTEM LICENSE '$(cat {{ sap_hana_deployment_license_path }}/{{ sap_hana_deployment_license_file_name }})';
       EOF
   args:
      executable: /bin/bash
   become: yes
-  become_user: "{{ hana_sid | lower }}adm"
+  become_user: "{{ sap_hana_deployment_hana_sid | lower }}adm"
   register: addlicense
   changed_when: "'0 rows affected' in addlicense.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,19 +2,19 @@
 
 - import_tasks: ev_user.yml
   when:
-    - hana_userid == ''
-    - not apply_license
+    - sap_hana_deployment_hana_userid == ''
+    - not sap_hana_deployment_apply_license
 
 - import_tasks: ev_group.yml
   when:
-    - hana_groupid == ''
-    - not apply_license
+    - sap_hana_deployment_hana_groupid == ''
+    - not sap_hana_deployment_apply_license
 
 - import_tasks: password_facts.yml
-  when: use_master_password == 'y'
+  when: sap_hana_deployment_use_master_password == 'y'
 
 - import_tasks: hana_deploy.yml
-  when: not apply_license
+  when: not sap_hana_deployment_apply_license
 
 - import_tasks: license.yml
-  when: apply_license
+  when: sap_hana_deployment_apply_license

--- a/tasks/password_facts.yml
+++ b/tasks/password_facts.yml
@@ -2,10 +2,10 @@
 
 - name: Set password facts when using single master password for all users
   set_fact:
-    sapadm_password: "{{ common_master_password }}"
-    sidadm_password: "{{ common_master_password }}"
-    hana_db_system_password: "{{ common_master_password }}"
-    ase_user_password: "{{ common_master_password }}"
-    xs_org_password: "{{ common_master_password }}"
-    lss_user_password: "{{ common_master_password }}"
-    lss_backup_password: "{{ common_master_password }}"
+    sap_hana_deployment_sapadm_password: "{{ sap_hana_deployment_common_master_password }}"
+    sap_hana_deployment_sidadm_password: "{{ sap_hana_deployment_common_master_password }}"
+    sap_hana_deployment_hana_db_system_password: "{{ sap_hana_deployment_common_master_password }}"
+    sap_hana_deployment_ase_user_password: "{{ sap_hana_deployment_common_master_password }}"
+    sap_hana_deployment_xs_org_password: "{{ sap_hana_deployment_common_master_password }}"
+    sap_hana_deployment_lss_user_password: "{{ sap_hana_deployment_common_master_password }}"
+    sap_hana_deployment_lss_backup_password: "{{ sap_hana_deployment_common_master_password }}"

--- a/templates/configfile.j2
+++ b/templates/configfile.j2
@@ -10,7 +10,7 @@ component_dirs=
 component_root=
 
 # Use single master password for all users, created during installation ( Default: n )
-use_master_password={{ use_master_password }}
+sap_hana_deployment_use_master_password={{ sap_hana_deployment_use_master_password }}
 
 # Skip all SAP Host Agent calls ( Default: n )
 skip_hostagent_calls=n
@@ -44,7 +44,7 @@ action=install
 use_pmem=n
 
 # Enable the installation or upgrade of the SAP Host Agent ( Default: y )
-install_hostagent={{ deploy_hostagent }}
+install_hostagent={{ sap_hana_deployment_deploy_hostagent }}
 
 # Database Isolation ( Default: low; Valid values: low | high )
 db_isolation=low
@@ -56,7 +56,7 @@ create_initial_tenant=y
 checkmnt=
 
 # Installation Path ( Default: /hana/shared )
-sapmnt={{ hana_install_path }}
+sapmnt={{ sap_hana_deployment_hana_install_path }}
 
 # Local Host Name
 hostname={{ ansible_hostname }}
@@ -68,10 +68,10 @@ install_ssh_key=y
 root_user=root
 
 # Root User Password
-root_password={{ root_password }}
+root_password={{ sap_hana_deployment_root_password }}
 
 # SAP Host Agent User (sapadm) Password
-sapadm_password={{ sapadm_password }}
+sapadm_password={{ sap_hana_deployment_sapadm_password }}
 
 # Directory containing a storage configuration
 storage_cfg=
@@ -83,61 +83,61 @@ listen_interface=
 internal_network=
 
 # SAP HANA System ID
-sid={{ hana_sid }}
+sid={{ sap_hana_deployment_hana_sid }}
 
 # Instance Number
-number={{ hana_instance_number }}
+number={{ sap_hana_deployment_hana_instance_number }}
 
 # Local Host Worker Group ( Default: default )
 workergroup=default
 
 # System Usage ( Default: custom; Valid values: production | test | development | custom )
-system_usage={{ hana_env_type }}
+system_usage={{ sap_hana_deployment_hana_env_type }}
 
 # Location of Data Volumes ( Default: /hana/data/${sid} )
-datapath=/hana/data/{{ hana_sid }}
+datapath=/hana/data/{{ sap_hana_deployment_hana_sid }}
 
 # Location of Log Volumes ( Default: /hana/log/${sid} )
-logpath=/hana/log/{{ hana_sid }}
+logpath=/hana/log/{{ sap_hana_deployment_hana_sid }}
 
 # Location of Persistent Memory Volumes ( Default: /hana/pmem/${sid} )
-pmempath=/hana/pmem/{{ hana_sid }}
+pmempath=/hana/pmem/{{ sap_hana_deployment_hana_sid }}
 
 # Directory containing custom configurations
 custom_cfg=
 
 # Restrict maximum memory allocation?
-restrict_max_mem={{ hana_mem_restrict }}
+restrict_max_mem={{ sap_hana_deployment_hana_mem_restrict }}
 
 # Maximum Memory Allocation in MB
-max_mem={{ hana_max_mem }}
+max_mem={{ sap_hana_deployment_hana_max_mem }}
 
 # Certificate Host Names
 certificates_hostmap=
 
 # Master Password
-master_password={{ common_master_password }}
+master_password={{ sap_hana_deployment_common_master_password }}
 
 # System Administrator Password
-password={{ sidadm_password }}
+password={{ sap_hana_deployment_sidadm_password }}
 
 # System Administrator Home Directory ( Default: /usr/sap/${sid}/home )
-home=/usr/sap/{{ hana_sid }}/home
+home=/usr/sap/{{ sap_hana_deployment_hana_sid }}/home
 
 # System Administrator Login Shell ( Default: /bin/sh )
 shell=/bin/sh
 
 # System Administrator User ID
-userid={{ hana_userid }}
+userid={{ sap_hana_deployment_hana_userid }}
 
 # ID of User Group (sapsys)
-groupid={{ hana_groupid }}
+groupid={{ sap_hana_deployment_hana_groupid }}
 
 # Database User (SYSTEM) Password
-system_user_password={{ hana_db_system_password }}
+system_user_password={{ sap_hana_deployment_hana_db_system_password }}
 
 # Restart system after machine reboot? ( Default: n )
-autostart={{ system_restart }}
+autostart={{ sap_hana_deployment_system_restart }}
 
 # Enable HANA repository ( Default: y )
 repository=y
@@ -165,12 +165,12 @@ import_xs_content=y
 [Client]
 
 # SAP HANA Database Client Installation Path ( Default: ${sapmnt}/${sid}/hdbclient )
-client_path={{ hana_install_path }}/{{ hana_sid }}/hdbclient
+client_path={{ sap_hana_deployment_hana_install_path }}/{{ sap_hana_deployment_hana_sid }}/hdbclient
 
 [Studio]
 
 # SAP HANA Studio Installation Path ( Default: ${sapmnt}/${sid}/hdbstudio )
-studio_path={{ hana_install_path }}/{{ hana_sid }}/hdbstudio
+studio_path={{ sap_hana_deployment_hana_install_path }}/{{ sap_hana_deployment_hana_sid }}/hdbstudio
 
 # Enables copying of SAP HANA Studio repository ( Default: y )
 studio_repository=y
@@ -189,28 +189,28 @@ reference_data_path=
 [XS_Advanced]
 
 # Install XS Advanced in the default tenant database? (y/n) ( Default: n )
-xs_use_default_tenant={{ xs_install }}
+xs_use_default_tenant={{ sap_hana_deployment_xs_install }}
 
 # XS Advanced App Working Path
-xs_app_working_path={{ xs_path }}
+xs_app_working_path={{ sap_hana_deployment_xs_path }}
 
 # Organization Name For Space "SAP" ( Default: orgname )
-org_name={{ xs_orgname }}
+org_name={{ sap_hana_deployment_xs_orgname }}
 
 # XS Advanced Admin User ( Default: XSA_ADMIN )
-org_manager_user={{ xs_org_user }}
+org_manager_user={{ sap_hana_deployment_xs_org_user }}
 
 # XS Advanced Admin User Password
-org_manager_password={{ xs_org_password }}
+org_manager_password={{ sap_hana_deployment_xs_org_password }}
 
 # Customer Space Name ( Default: PROD )
-prod_space_name={{ xs_prod_space }}
+prod_space_name={{ sap_hana_deployment_xs_prod_space }}
 
 # Routing Mode ( Default: ports; Valid values: ports | hostnames )
-xs_routing_mode={{ xs_routing_mode }}
+xs_routing_mode={{ sap_hana_deployment_xs_routing_mode }}
 
 # XS Advanced Domain Name (see SAP Note 2245631)
-xs_domain_name={{ xs_domain_name }}
+xs_domain_name={{ sap_hana_deployment_xs_domain_name }}
 
 # Run Applications in SAP Space with Separate OS User (y/n) ( Default: y )
 xs_sap_space_isolation=y
@@ -219,16 +219,16 @@ xs_sap_space_isolation=y
 xs_customer_space_isolation=y
 
 # XS Advanced SAP Space OS User ID
-xs_sap_space_user_id={{ xs_sap_space_user }}
+xs_sap_space_user_id={{ sap_hana_deployment_xs_sap_space_user }}
 
 # XS Advanced Customer Space OS User ID
-xs_customer_space_user_id={{ xs_customer_space_user }}
+xs_customer_space_user_id={{ sap_hana_deployment_xs_customer_space_user }}
 
 # XS Advanced Components
-xs_components={{ xs_components }} (CSV)
+xs_components={{ sap_hana_deployment_xs_components }} (CSV)
 
 # Do not start the selected XS Advanced components after installation ( Default: none )
-xs_components_nostart={{ xs_components_nostart }}
+xs_components_nostart={{ sap_hana_deployment_xs_components_nostart }}
 
 # XS Advanced Components Configurations
 xs_components_cfg=
@@ -248,22 +248,22 @@ xs_trust_pem=
 lss_inst_path=/lss/shared
 
 # Local Secure Store User Password
-lss_user_password={{ lss_user_password }}
+lss_user_password={{ sap_hana_deployment_lss_user_password }}
 
 # Local Secure Store User ID
-lss_userid={{ lss_user }}
+lss_userid={{ sap_hana_deployment_lss_user }}
 
 # Local Secure Store User Group ID
-lss_groupid={{ lss_group }}
+lss_groupid={{ sap_hana_deployment_lss_group }}
 
 # Local Secure Store User Home Directory ( Default: /usr/sap/${sid}/lss/home )
-lss_user_home=/usr/sap/{{ hana_sid }}/lss/home
+lss_user_home=/usr/sap/{{ sap_hana_deployment_hana_sid }}/lss/home
 
 # Local Secure Store User Login Shell ( Default: /bin/sh )
 lss_user_shell=/bin/sh
 
 # Local Secure Store Auto Backup Password
-lss_backup_password={{ lss_backup_password }}
+lss_backup_password={{ sap_hana_deployment_lss_backup_password }}
 
 [streaming]
 
@@ -271,26 +271,26 @@ lss_backup_password={{ lss_backup_password }}
 streaming_cluster_manager_password=
 
 # Location of Streaming logstores and runtime information ( Default: /hana/data_streaming/${sid} )
-basepath_streaming=/hana/data_streaming/{{ hana_sid }}
+basepath_streaming=/hana/data_streaming/{{ sap_hana_deployment_hana_sid }}
 
 [es]
 
 # Location of Dynamic Tiering Data Volumes ( Default: /hana/data_es/${sid} )
-es_datapath=/hana/data_es/{{ hana_sid }}
+es_datapath=/hana/data_es/{{ sap_hana_deployment_hana_sid }}
 
 # Location of Dynamic Tiering Log Volumes ( Default: /hana/log_es/${sid} )
-es_logpath=/hana/log_es/{{ hana_sid }}
+es_logpath=/hana/log_es/{{ sap_hana_deployment_hana_sid }}
 
 [ets]
 
 # Location of Data Volumes of the Accelerator for SAP ASE ( Default: /hana/data_ase/${sid} )
-ase_datapath=/hana/data_ase/{{ hana_sid }}
+ase_datapath=/hana/data_ase/{{ sap_hana_deployment_hana_sid }}
 
 # Location of Log Volumes of the Accelerator for SAP ASE ( Default: /hana/log_ase/${sid} )
-ase_logpath=/hana/log_ase/{{ hana_sid }}
+ase_logpath=/hana/log_ase/{{ sap_hana_deployment_hana_sid }}
 
 # SAP ASE Administrator User ( Default: sa )
 ase_user=sa
 
 # SAP ASE Administrator Password
-ase_user_password={{ ase_user_password }}
+ase_user_password={{ sap_hana_deployment_ase_user_password }}


### PR DESCRIPTION
- Normalize vars names with ansible best practices
- Fix not mandatory role vars on README
- Remove deprecated Python version from CI
- Fix ansible lint line length 

Fixes #5  