### PR TITLE
Added flexible HANA provisioning capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ It is also important that your disks are setup according to the [SAP storage req
 
 | variable | info | required? |
 |:--------:|:----:|:---------:|
-|sap_hana_deployment_bundle_path|Target host directory path where SAP Installation Bundle SAR file is located|yes|
-|sap_hana_deployment_bundle_sar_file_name|Installation Bundle SAR file name|yes|
-|sap_hana_deployment_sapcar_path|Target host directory directory path where SAPCAR tool file is located|yes|
-|sap_hana_deployment_sapcar_file_name|SAPCAR tool file name|yes|
+|sap_hana_installdir| directory, where hdblcm is located | No, if `sap_hana_deployment_bundle_path`, `sap_hana_deployment_bundle_sar_file_name`, `sap_hana_deployment_sapcar_path` and `sap_hana_deployment_sapcar_file_name`	are defined.|
+|sap_hana_deployment_bundle_path|Target host directory path where SAP Installation Bundle SAR file is located|yes, unless `sap_hana_installdir` is defined|
+|sap_hana_deployment_bundle_sar_file_name|Installation Bundle SAR file name|yes, unless `sap_hana_installdir` is defined|
+|sap_hana_deployment_sapcar_path|Target host directory directory path where SAPCAR tool file is located|yes, unless `sap_hana_installdir` is defined|
+|sap_hana_deployment_sapcar_file_name|SAPCAR tool file name|yes, unless `sap_hana_installdir` is defined|
 |sap_hana_deployment_deploy_hostagent|Whatever you want to deploy SAP HostAgent or not|no, defaulted to `n` value|
 |sap_hana_deployment_use_master_password|Use single master password for all users, created during installation|no, defaulted to `n` value|
 |sap_hana_deployment_common_master_password|Common password for both OS users and DB Administrator user (SYSTEM)|no, only if sap_hana_deployment_use_master_password is `y`|

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ It is also important that your disks are setup according to the [SAP storage req
 
 ## Role Variables
 
-| variable | info | required? |
-|:--------:|:----:|:---------:|
+| variable |             info             | required? |
+|:--------:|:----------------------------:|:---------:|
 |sap_hana_installdir| directory, where hdblcm is located | No, if `sap_hana_deployment_bundle_path`, `sap_hana_deployment_bundle_sar_file_name`, `sap_hana_deployment_sapcar_path` and `sap_hana_deployment_sapcar_file_name`	are defined.|
 |sap_hana_deployment_bundle_path|Target host directory path where SAP Installation Bundle SAR file is located|yes, unless `sap_hana_installdir` is defined|
 |sap_hana_deployment_bundle_sar_file_name|Installation Bundle SAR file name|yes, unless `sap_hana_installdir` is defined|
 |sap_hana_deployment_sapcar_path|Target host directory directory path where SAPCAR tool file is located|yes, unless `sap_hana_installdir` is defined|
 |sap_hana_deployment_sapcar_file_name|SAPCAR tool file name|yes, unless `sap_hana_installdir` is defined|
+|sap_hana_deployment_hdblcm_extraargs| define extra commandline arguments to hdblcm, such as `--ignore=check1[,check2]` | No |
 |sap_hana_deployment_deploy_hostagent|Whatever you want to deploy SAP HostAgent or not|no, defaulted to `n` value|
 |sap_hana_deployment_use_master_password|Use single master password for all users, created during installation|no, defaulted to `n` value|
 |sap_hana_deployment_common_master_password|Common password for both OS users and DB Administrator user (SYSTEM)|no, only if sap_hana_deployment_use_master_password is `y`|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,10 @@ sap_hana_deployment_bundle_sar_file_name:
 sap_hana_deployment_sapcar_path:
 sap_hana_deployment_sapcar_file_name:
 
+# if the previous variables are undefined because you do not want to provide a bundle
+# you can define sap_hana_installdir variable, which points to the directory containing hdblcm
+# the role sap-hana-mediacheck can be used to define this variable
+
 # Target host path and file name for the license file
 sap_hana_deployment_license_path:
 sap_hana_deployment_license_file_name:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ sap_hana_deployment_sapcar_file_name:
 sap_hana_deployment_license_path:
 sap_hana_deployment_license_file_name:
 
+# Pass some extra arguments to the hdblcm cli, e.g.  --ignore=<check1>[,<check2>]...
+# Specifies failing preequisite checks that the SAP HANA platform lifecycle management tools should ignore.
+sap_hana_deployment_hdblcm_extraargs:
 
 # Response variables for unattended installation config file
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ sap_hana_deployment_sapcar_file_name:
 # if the previous variables are undefined because you do not want to provide a bundle
 # you can define sap_hana_installdir variable, which points to the directory containing hdblcm
 # the role sap-hana-mediacheck can be used to define this variable
+sap_hana_installdir:
 
 # Target host path and file name for the license file
 sap_hana_deployment_license_path:

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -1,18 +1,29 @@
 ---
 
-- name: Use SAPCAR to extract the SAP HANA Bundle SAR file
-  command: >-
-    {{ sap_hana_deployment_sapcar_path }}/{{ sap_hana_deployment_sapcar_file_name }} \
-    -xvf {{ sap_hana_deployment_bundle_path }}/{{ sap_hana_deployment_bundle_sar_file_name }} \
-    -manifest SIGNATURE.SMF
-  register: extractbundle
-  args:
-    chdir: "{{ sap_hana_deployment_sapcar_path }}"
-  changed_when: "'SAPCAR: processing archive' in extractbundle.stdout"
+- name: Unpack SAPCAR archive (backwards compatibility)
+  block:
+    - name: Use SAPCAR to extract the SAP HANA Bundle SAR file
+      command: >-
+        {{ sap_hana_deployment_sapcar_path }}/{{ sap_hana_deployment_sapcar_file_name }} \
+        -xvf {{ sap_hana_deployment_bundle_path }}/{{ sap_hana_deployment_bundle_sar_file_name }} \
+        -manifest SIGNATURE.SMF
+      register: sap_hana_deployment_register_extractbundle
+      args:
+        chdir: "{{ sap_hana_deployment_sapcar_path }}"
+      changed_when: "'SAPCAR: processing archive' in sap_hana_deployment_register_extractbundle.stdout"
+    
+    - name: Setting fact for HANA installer path
+      set_fact:
+        sap_hana_installdir: "{{ sap_hana_deployment_sapcar_path }}/SAP_HANA_DATABASE"
+  when:
+    - not((sap_hana_deployment_bundle_path is undefined) or ( sap_hana_deployment_bundle_path is none) or (sap_hana_deployment_bundle_path | trim == '') )
+    - not((sap_hana_deployment_bundle_sar_file_name) or ( sap_hana_deployment_bundle_sar_file_name ) or (sap_hana_deployment_bundle_sar_file_name | trim == '') )
 
-- name: Setting fact for HANA installer path
-  set_fact:
-    hana_source_path: "{{ sap_hana_deployment_sapcar_path }}/SAP_HANA_DATABASE"
+- name: Check availability of "{{ sap_hana_installdir + '/' + hdblcm }}" 
+  stat:
+          path: "{{ sap_hana_installdir + '/' + hdblcm }}"
+  register: sap_hana_deployment_register_hdblcm_stat
+  failed_when: not sap_hana_deployment_register_hdblcm_stat.stat.exists
 
 - name: create temporary directory to store the processed template
   tempfile:
@@ -30,5 +41,5 @@
   command: "./hdblcm --configfile={{ tmpdir.path }}/configfile.cfg -b"
   register: installhana
   args:
-    chdir: "{{ hana_source_path }}"
+    chdir: "{{ sap_hana_installdir }}"
   changed_when: "'SAP HANA Lifecycle Management' in installhana.stdout"

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -16,8 +16,8 @@
       set_fact:
         sap_hana_installdir: "{{ sap_hana_deployment_sapcar_path }}/SAP_HANA_DATABASE"
   when:
-    - not((sap_hana_deployment_bundle_path is undefined) or ( sap_hana_deployment_bundle_path is none) or (sap_hana_deployment_bundle_path | trim == '') )
-    - not((sap_hana_deployment_bundle_sar_file_name is undefined) or (sap_hana_deployment_bundle_sar_file_name is none) or (sap_hana_deployment_bundle_sar_file_name | trim == ''))
+    - not(( sap_hana_deployment_bundle_path is none ) or ( sap_hana_deployment_bundle_path | trim == ''))
+    - not(( sap_hana_deployment_bundle_sar_file_name is none ) or (sap_hana_deployment_bundle_sar_file_name | trim == ''))
 
 - name: Check availability of "{{ sap_hana_installdir + '/hdblcm' }}"
   stat:

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -38,7 +38,7 @@
   register: cftemplate
 
 - name: Install SAP HANA
-  command: "./hdblcm --configfile={{ tmpdir.path }}/configfile.cfg -b"
+  command: "./hdblcm {{ sap_hana_deployment_hdblcm_extraargs }} --configfile={{ tmpdir.path }}/configfile.cfg -b"
   register: installhana
   args:
     chdir: "{{ sap_hana_installdir }}"

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -19,9 +19,9 @@
     - not((sap_hana_deployment_bundle_path is undefined) or ( sap_hana_deployment_bundle_path is none) or (sap_hana_deployment_bundle_path | trim == '') )
     - not((sap_hana_deployment_bundle_sar_file_name) or ( sap_hana_deployment_bundle_sar_file_name ) or (sap_hana_deployment_bundle_sar_file_name | trim == '') )
 
-- name: Check availability of "{{ sap_hana_installdir + '/' + hdblcm }}" 
+- name: Check availability of "{{ sap_hana_installdir + '/hdblcm' }}" 
   stat:
-          path: "{{ sap_hana_installdir + '/' + hdblcm }}"
+          path: "{{ sap_hana_installdir + '/hdblcm' }}"
   register: sap_hana_deployment_register_hdblcm_stat
   failed_when: not sap_hana_deployment_register_hdblcm_stat.stat.exists
 

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -17,7 +17,7 @@
         sap_hana_installdir: "{{ sap_hana_deployment_sapcar_path }}/SAP_HANA_DATABASE"
   when:
     - not((sap_hana_deployment_bundle_path is undefined) or ( sap_hana_deployment_bundle_path is none) or (sap_hana_deployment_bundle_path | trim == '') )
-    - not((sap_hana_deployment_bundle_sar_file_name) or (sap_hana_deployment_bundle_sar_file_name) or (sap_hana_deployment_bundle_sar_file_name | trim == ''))
+    - not((sap_hana_deployment_bundle_sar_file_name is undefined) or (sap_hana_deployment_bundle_sar_file_name is none) or (sap_hana_deployment_bundle_sar_file_name | trim == ''))
 
 - name: Check availability of "{{ sap_hana_installdir + '/hdblcm' }}"
   stat:

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -11,15 +11,15 @@
       args:
         chdir: "{{ sap_hana_deployment_sapcar_path }}"
       changed_when: "'SAPCAR: processing archive' in sap_hana_deployment_register_extractbundle.stdout"
-    
+
     - name: Setting fact for HANA installer path
       set_fact:
         sap_hana_installdir: "{{ sap_hana_deployment_sapcar_path }}/SAP_HANA_DATABASE"
   when:
     - not((sap_hana_deployment_bundle_path is undefined) or ( sap_hana_deployment_bundle_path is none) or (sap_hana_deployment_bundle_path | trim == '') )
-    - not((sap_hana_deployment_bundle_sar_file_name) or ( sap_hana_deployment_bundle_sar_file_name ) or (sap_hana_deployment_bundle_sar_file_name | trim == '') )
+    - not((sap_hana_deployment_bundle_sar_file_name) or (sap_hana_deployment_bundle_sar_file_name) or (sap_hana_deployment_bundle_sar_file_name | trim == ''))
 
-- name: Check availability of "{{ sap_hana_installdir + '/hdblcm' }}" 
+- name: Check availability of "{{ sap_hana_installdir + '/hdblcm' }}"
   stat:
           path: "{{ sap_hana_installdir + '/hdblcm' }}"
   register: sap_hana_deployment_register_hdblcm_stat

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -21,7 +21,7 @@
 
 - name: Check availability of "{{ sap_hana_installdir + '/hdblcm' }}"
   stat:
-          path: "{{ sap_hana_installdir + '/hdblcm' }}"
+    path: "{{ sap_hana_installdir + '/hdblcm' }}"
   register: sap_hana_deployment_register_hdblcm_stat
   failed_when: not sap_hana_deployment_register_hdblcm_stat.stat.exists
 


### PR DESCRIPTION
I have changed the internal internal only variable hana_source_path to sap_hana_installdir. When the variable sap_hana_installdir is defined and the variables for the sar bundle are undefined the role now skips the unpacking block. So it stays fully backwardscompatible with previous functionality
If sap_hana_installdir is defined , the role checks if hdblcm exists in this directory, otherwise it stops with an error.
Now sap-hana-mediacheck can be used to mount or unpack hana archives from any location in the network.
