### PR TITLE
Use remote src

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,3 +65,11 @@ sap_hana_deployment_lss_group:
 sap_hana_deployment_lss_user_password:
 sap_hana_deployment_lss_backup_password:
 sap_hana_deployment_ase_user_password:
+
+# for ZIP Archive use remote_src yes in case the zip file is already placed on the target node
+sap_hana_deployment_zip_archive_remote_src: no
+
+# Copy ZIP archive from local node to target node
+sap_hana_deployment_copy_zip_archive: false
+sap_hana_deployment_zip_local_file: /tmp/file.ZIP
+

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -21,11 +21,17 @@
 
 - name: Extract ZIP archive
   block:
+    - name: Copy SAP ZIP file - This may take a while
+      synchronize:
+        src: "{{ sap_hana_deployment_zip_local_file }}"
+        dest: "{{ sap_hana_deployment_zip_path }}/{{ sap_hana_deployment_zip_file_name }}"
+      when: sap_hana_deployment_copy_zip_archive|bool == true
+
     - name: Use unarchive to extract the SAP HANA Bundle ZIP file
       unarchive:
         src: "{{ sap_hana_deployment_zip_path }}/{{ sap_hana_deployment_zip_file_name }}"
         dest: "{{ sap_hana_deployment_zip_path }}"
-        mode: '0755'
+        remote_src: "{{ sap_hana_deployment_zip_archive_remote_src }}"
       register: sap_hana_deployment_register_extractzip
 
     - name: Setting fact for HANA installer path
@@ -54,7 +60,7 @@
   register: cftemplate
 
 - name: Install SAP HANA
-  shell: "umask 022; ./hdblcm {{ sap_hana_deployment_hdblcm_extraargs }} --configfile={{ tmpdir.path }}/configfile.cfg -b"
+  command: "./hdblcm {{ sap_hana_deployment_hdblcm_extraargs }} --configfile={{ tmpdir.path }}/configfile.cfg -b"
   register: installhana
   args:
     chdir: "{{ sap_hana_installdir }}"

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -25,7 +25,7 @@
       synchronize:
         src: "{{ sap_hana_deployment_zip_local_file }}"
         dest: "{{ sap_hana_deployment_zip_path }}/{{ sap_hana_deployment_zip_file_name }}"
-      when: sap_hana_deployment_copy_zip_archive|bool == true
+      when: sap_hana_deployment_copy_zip_archive|bool
 
     - name: Use unarchive to extract the SAP HANA Bundle ZIP file
       unarchive:

--- a/tasks/hana_deploy.yml
+++ b/tasks/hana_deploy.yml
@@ -25,6 +25,7 @@
       unarchive:
         src: "{{ sap_hana_deployment_zip_path }}/{{ sap_hana_deployment_zip_file_name }}"
         dest: "{{ sap_hana_deployment_zip_path }}"
+        mode: '0755'
       register: sap_hana_deployment_register_extractzip
 
     - name: Setting fact for HANA installer path
@@ -53,7 +54,7 @@
   register: cftemplate
 
 - name: Install SAP HANA
-  command: "./hdblcm {{ sap_hana_deployment_hdblcm_extraargs }} --configfile={{ tmpdir.path }}/configfile.cfg -b"
+  shell: "umask 022; ./hdblcm {{ sap_hana_deployment_hdblcm_extraargs }} --configfile={{ tmpdir.path }}/configfile.cfg -b"
   register: installhana
   args:
     chdir: "{{ sap_hana_installdir }}"


### PR DESCRIPTION
During "unarchive zip" Ansible will use the remote_tmp folder to extract the data temporarily. Per default this is set to the users home directory. In many installation the /home directory is very limited in size. Therefore, I wonder if this pull request can be reused. 

It would copy (synchronize) the archive to a destinition folder (without bothering the /home), if "sap_hana_deployment_copy_zip_archive" is set to true. If it stays on false the file must be copied manually.

Moreover, it tells the unarchive module, that the file is already at the remote server. 